### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/backend/test-login.js
+++ b/backend/test-login.js
@@ -28,7 +28,6 @@ async function testLogin() {
       const admin = adminResults[0];
       console.log('Email:', admin.email);
       console.log('User Type:', admin.user_type);
-      console.log('Password Hash:', admin.password.substring(0, 30) + '...');
       
       const isValid = await bcrypt.compare('admin123', admin.password);
       console.log('Password "admin123" is valid:', isValid);
@@ -45,7 +44,6 @@ async function testLogin() {
       const oper = operResults[0];
       console.log('Email:', oper.email);
       console.log('User Type:', oper.user_type);
-      console.log('Password Hash:', oper.password.substring(0, 30) + '...');
       
       const isValid = await bcrypt.compare('oper123', oper.password);
       console.log('Password "oper123" is valid:', isValid);


### PR DESCRIPTION
Potential fix for [https://github.com/MrCasuela/ingenieriaSoftware-Boleteria/security/code-scanning/3](https://github.com/MrCasuela/ingenieriaSoftware-Boleteria/security/code-scanning/3)

To fix the problem, avoid logging the `password` or its hash in any form. Only log non-sensitive user information, such as `email` and `user_type`. Specifically, in `backend/test-login.js`, remove or comment out the lines that log `admin.password.substring(0, 30) + '...'` and `oper.password.substring(0, 30) + '...'`. This change only affects logging and does not interfere with authentication logic, as the comparison itself is still performed. No new imports or methods are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
